### PR TITLE
chore: add .dockerignore for frontend

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.git
+.env
+.next/
+build/
+dist/
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+.DS_Store


### PR DESCRIPTION
# 概要
フロントエンドアプリに対応する.dockerignoreの設置

# 背景
issue: [#16](https://github.com/1068haruto/python_study/issues/16)

# 主な変更点
1. ビルド時間の短縮（設置前: 20.7s　→　設置後: 0.8s）
2. ビルドコンテキスト転送量の削減（設置前：280.47MB　→　設置後：929B）