### PR TITLE
feat: display user_id after user creation

### DIFF
--- a/frontend/src/app/users/create/CreateForm.tsx
+++ b/frontend/src/app/users/create/CreateForm.tsx
@@ -8,6 +8,7 @@ export default function CreateForm() {
   const [name, setName] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+  const [userId, setUserId] = useState<number | null>(null);
 
   // フォーム送信時に実行
   const handleSubmit = async (e: React.FormEvent) => {
@@ -19,6 +20,7 @@ export default function CreateForm() {
     });
     const data = await res.json();
     setMessage(data.message);
+    setUserId(data.user_id);
   };
 
   return (
@@ -28,6 +30,7 @@ export default function CreateForm() {
       <input type="password" placeholder="パスワード" value={password} onChange={(e) => setPassword(e.target.value)} />
       <button type="submit">作成</button>
       <p>{message}</p>
+      {userId !== null && <p>ユーザーID: {userId}</p>}
     </form>
   );
 }


### PR DESCRIPTION
# 概要
ユーザー作成後のid表示を追加

# 背景
issue: [#24](https://github.com/1068haruto/python_study/issues/24) (親: [#5](https://github.com/1068haruto/python_study/issues/5))

# 主な変更点
- 概要と同じ