### PR TITLE
Feat/user

### DIFF
--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -6,21 +6,25 @@
   margin: 50px auto;
   gap: 12px;
 
+  .title {
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+  }
+
   .links {
     display: flex;
     flex-direction: column;
-  	gap: 12px;
 
-	button {
-      padding: 8px;
+    .linkButton {
+      padding: 0.5rem 1rem;
       background-color: #14375e;
       color: white;
-	  border: none;
-      cursor: pointer;
+      font-size: 1rem;
+    	cursor: pointer;
 
       &:hover {
         background-color: #005dc1;
-	  }
-  	}
+      }
+    }
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,14 +4,10 @@ import styles from './page.module.scss';
 export default function Home() {
   return (
     <main className={styles.main}>
-      <h1>Home</h1>
-      <p>ユーザーの作成と削除ができる</p>
-
+      <h1 className={styles.title}>🏠ホーム</h1>
+      <p>機能を選択</p>
       <div className={styles.links}>
-        <Link href="/users/list"><button>一覧ページ</button></Link>
-        <Link href="/users/create"><button>作成ページ</button></Link>
-        <Link href="/users/update"><button>更新ページ</button></Link>
-        <Link href="/users/delete"><button>削除ページ</button></Link>
+        <Link href="/users" className={styles.linkButton}>ユーザー機能</Link>
       </div>
     </main>
   );

--- a/frontend/src/app/users/UsersPage.module.scss
+++ b/frontend/src/app/users/UsersPage.module.scss
@@ -1,0 +1,26 @@
+.container {
+  padding: 2rem;
+
+  .title {
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+  }
+
+  .buttonGroup {
+  	display: flex;
+  	margin-bottom: 1.5rem;
+  	gap: 1rem;
+
+  	button {
+    	padding: 0.5rem 1rem;
+    	background-color: #14375e;
+    	color: white;
+    	font-size: 1rem;
+			cursor: pointer;
+
+    	&:hover {
+      	background-color: #005dc1;
+    	}
+  	}
+	}
+}

--- a/frontend/src/app/users/create/page.tsx
+++ b/frontend/src/app/users/create/page.tsx
@@ -1,9 +1,0 @@
-import CreateForm from './CreateForm';
-
-export default function CreateUserPage() {
-  return (
-    <main>
-      <CreateForm />
-    </main>
-  );
-}

--- a/frontend/src/app/users/delete/page.tsx
+++ b/frontend/src/app/users/delete/page.tsx
@@ -1,9 +1,0 @@
-import DeleteButton from './DeleteButton';
-
-export default function DeleteUserPage() {
-  return (
-    <main>
-      <DeleteButton />
-    </main>
-  );
-}

--- a/frontend/src/app/users/list/page.tsx
+++ b/frontend/src/app/users/list/page.tsx
@@ -1,9 +1,0 @@
-import UserList from './UserList';
-
-export default function UserListPage() {
-  return (
-    <main>
-      <UserList />
-    </main>
-  );
-}

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import CreateForm from './create/CreateForm';
+import DeleteButton from './delete/DeleteButton';
+import UpdateForm from './update/UpdateForm';
+import UserList from './list/UserList';
+import styles from './UsersPage.module.scss';
+
+export default function UsersPage() {
+  const [activeTab, setActiveTab] = useState<'create' | 'list' | 'update' | 'delete' | null>(null);
+	const router = useRouter();
+
+  return (
+    <main className={styles.container}>
+      <h1 className={styles.title}>👤ユーザー機能</h1>
+
+      {/* ナビゲーションボタン */}
+      <div className={styles.buttonGroup}>
+        <button onClick={() => setActiveTab('create')}>作成</button>
+				<button onClick={() => setActiveTab('list')}>一覧</button>
+        <button onClick={() => setActiveTab('update')}>更新</button>
+				<button onClick={() => setActiveTab('delete')}>削除</button>
+				<button onClick={() => router.push('/')}>ホームに戻る</button> {/* ← 追加 */}
+      </div>
+
+      {/* 表示エリア */}
+      <div>
+        {activeTab === 'create' && <CreateForm />}
+				{activeTab === 'list' && <UserList />}
+        {activeTab === 'update' && <UpdateForm />}
+				{activeTab === 'delete' && <DeleteButton />}
+        {!activeTab && <p>操作を選択してください。</p>}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/users/update/page.tsx
+++ b/frontend/src/app/users/update/page.tsx
@@ -1,9 +1,0 @@
-import UpdateForm from './UpdateForm';
-
-export default function UpdateUserPage() {
-  return (
-    <main>
-      <UpdateForm />
-    </main>
-  );
-}


### PR DESCRIPTION
# 概要
ユーザーCRUD機能に対応するページを1つのページに集約。

# 背景
issue: [#30](https://github.com/1068haruto/python_study/issues/30)

# 変更点
- users/page.tsxを新規作成し、それぞれのCRUD操作画面に対応するボタンを設置。
  （複数のページ移動する仕様を辞め❌　→　同じページ内で表示を切り替える仕様に改善⭕️）
- app/page.tsxの改善。