### PR TITLE
chore: update MySQL client character set to utf8mb4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     volumes:
       - ./db:/var/lib/mysql
+      - ./docker/mysql/conf.d:/etc/mysql/conf.d  # 文字化けさせないためにマウント
     env_file:
       - .env
 

--- a/docker/mysql/conf.d/my.cnf
+++ b/docker/mysql/conf.d/my.cnf
@@ -1,0 +1,9 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci


### PR DESCRIPTION
# 概要
データベースに保存された値の文字化け解消。（解決）

# 背景
issue: [#32](https://github.com/1068haruto/python_study/issues/32)

# 変更点
- docker/mysql/conf.d/my.cnfを作成し、MySQLクライアントで使用する文字コードを定義
- docker-compose.ymlに、上記ファイルのマウントを定義
適切に文字が表示されるようになった。

# 原因と解決策
### 原因
該当のテーブルとデータベース自体は「utf8mb4」だが、MySQLクライアントが「latin1」となっている。
これにより、適切に値は保存されるが、表示は崩れるという現象が起きている。
### 解決策
現状、クライアントはdocker経由で導入している（ローカルではない）ため、docker内で「クライアントがutf8mb4を使用する」設定を行う。
DBへのログインする都度、文字コード指定するのは面倒なので、設定ファイルをマウントする仕様とした。