### PR TITLE
feat: login form

### DIFF
--- a/frontend/src/app/users/login/LoginForm.module.scss
+++ b/frontend/src/app/users/login/LoginForm.module.scss
@@ -1,0 +1,25 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  max-width: 400px;
+  margin: 50px auto;
+  gap: 12px;
+
+  input {
+    padding: 8px;
+    font-size: 16px;
+    background-color: rgb(29, 29, 29);
+  }
+
+  button {
+    padding: 8px;
+    background-color: #14375e;
+    color: white;
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+			background-color: #005dc1;
+    }
+  }
+}

--- a/frontend/src/app/users/login/LoginForm.tsx
+++ b/frontend/src/app/users/login/LoginForm.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './LoginForm.module.scss';
+
+export default function LoginForm() {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [token, setToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const loginRes = await fetch('http://localhost:8000/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password }),
+      });
+
+      if (!loginRes.ok) throw new Error('ログイン失敗');
+
+      const data = await loginRes.json();
+      setToken(data.access_token);
+
+      const meRes = await fetch('http://localhost:8000/me', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${data.access_token}`,
+        },
+      });
+
+      if (!meRes.ok) throw new Error('認証失敗');
+
+      const me = await meRes.json();
+      setMessage(`ログイン成功！こんにちは ${me.name} さん`);
+    } catch (err) {
+      setMessage('ログインに失敗した。');
+      setToken('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleLogin} className={styles.form}>
+      <h1>ログイン</h1>
+      <input type="text" placeholder="ユーザー名" value={name} onChange={(e) => setName(e.target.value)} />
+      <input type="password" placeholder="パスワード" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <button type="submit">ログイン</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import LoginForm from './login/LoginForm'
 import CreateForm from './create/CreateForm';
 import DeleteButton from './delete/DeleteButton';
 import UpdateForm from './update/UpdateForm';
@@ -9,7 +10,7 @@ import UserList from './list/UserList';
 import styles from './UsersPage.module.scss';
 
 export default function UsersPage() {
-  const [activeTab, setActiveTab] = useState<'create' | 'list' | 'update' | 'delete' | null>(null);
+  const [activeTab, setActiveTab] = useState<'login' | 'create' | 'list' | 'update' | 'delete' | null>(null);
 	const router = useRouter();
 
   return (
@@ -18,6 +19,7 @@ export default function UsersPage() {
 
       {/* ナビゲーションボタン */}
       <div className={styles.buttonGroup}>
+        <button onClick={() => setActiveTab('login')}>ログイン</button>
         <button onClick={() => setActiveTab('create')}>作成</button>
 				<button onClick={() => setActiveTab('list')}>一覧</button>
         <button onClick={() => setActiveTab('update')}>更新</button>
@@ -27,6 +29,7 @@ export default function UsersPage() {
 
       {/* 表示エリア */}
       <div>
+        {activeTab === 'login' && <LoginForm />}
         {activeTab === 'create' && <CreateForm />}
 				{activeTab === 'list' && <UserList />}
         {activeTab === 'update' && <UpdateForm />}


### PR DESCRIPTION
# 概要
ログインフォームの設置

# 背景
issue: [#36](https://github.com/1068haruto/python_study/issues/36)

# 変更点
- frontend/src/app/users/login/を作成し、ログインフォーム・スタイルを追加
- GUIからログインリクエストを送り、認証済の状態を作れるようになった。
    (- 認証している/いないの状態に対応するページや内容表示の制御はしていない)