### PR TITLE
Feat/user

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -24,7 +24,7 @@ def login(request: LoginRequest, db: Session = Depends(get_db)):
         key="access_token",
         value=access_token,
         httponly=True,
-        secure=False,  # ローカル環境なので False
+        secure=False,
         samesite="Lax"
     )
     return response

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -12,9 +12,7 @@
   	gap: 1rem;
 
 
-  	button,
-    a {
-      // Linkは <a>タグとしてレンダリングされる為、セレクタにaも指定し、同スタイルを適用。
+    a {  // Linkは <a>タグとしてレンダリングされる
     	padding: 0.5rem 1rem;
     	background-color: #14375e;
     	color: white;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,27 +1,17 @@
 'use client'
 
-import { useState } from 'react';
 import Link from 'next/link';
-import LoginForm from './users/login/LoginForm'
 import styles from './page.module.scss';
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState<'login' | null>(null);
-
   return (
     <main className={styles.container}>
       <h1 className={styles.title}>🏠ホーム</h1>
 
       {/* ナビゲーションボタン */}
       <div className={styles.buttonGroup}>
-        <button onClick={() => setActiveTab('login')}>ログイン</button>
         <Link href="/users">ユーザー機能</Link>
       </div>
-
-      {/* 表示エリア */}
-        <div>
-          {activeTab === 'login' && <LoginForm />}
-        </div>
     </main>
   );
 }

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -2,16 +2,20 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import LogoutButton from './logout/LogoutButton'
+import { useAuth } from '@/contexts/AuthContext';
+import LoginForm from './login/LoginForm';
+import LogoutButton from './logout/LogoutButton';
 import CreateForm from './create/CreateForm';
 import DeleteButton from './delete/DeleteButton';
 import UpdateForm from './update/UpdateForm';
 import UserList from './list/UserList';
 import styles from './UsersPage.module.scss';
 
+
 export default function UsersPage() {
-  const [activeTab, setActiveTab] = useState<'logout' | 'create' | 'list' | 'update' | 'delete' | null>(null);
+  const [activeTab, setActiveTab] = useState<'login' |'logout' | 'create' | 'list' | 'update' | 'delete' | null>(null);
 	const router = useRouter();
+  const { user } = useAuth();
 
   return (
     <main className={styles.container}>
@@ -19,21 +23,32 @@ export default function UsersPage() {
 
       {/* ナビゲーションボタン */}
       <div className={styles.buttonGroup}>
-        <button onClick={() => setActiveTab('logout')}>ログアウト</button>
-        <button onClick={() => setActiveTab('create')}>作成</button>
-				<button onClick={() => setActiveTab('list')}>一覧</button>
-        <button onClick={() => setActiveTab('update')}>更新</button>
-				<button onClick={() => setActiveTab('delete')}>削除</button>
-				<button onClick={() => router.push('/')}>ホームに戻る</button>
+        {!user ? (
+          <>
+            <button onClick={() => setActiveTab('login')}>ログイン</button>
+            <button onClick={() => setActiveTab('create')}>作成</button>
+            <button onClick={() => router.push('/')}>ホームに戻る</button>
+          </>
+        ) : (
+          <>
+            <button onClick={() => setActiveTab('logout')}>ログアウト</button>
+            <button onClick={() => setActiveTab('create')}>作成</button>
+            <button onClick={() => setActiveTab('list')}>一覧</button>
+            <button onClick={() => setActiveTab('update')}>更新</button>
+				    <button onClick={() => setActiveTab('delete')}>削除</button>
+            <button onClick={() => router.push('/')}>ホームに戻る</button>
+          </>
+        )}
       </div>
 
       {/* 表示エリア */}
       <div>
-        {activeTab === 'logout' && <LogoutButton />}
+        {activeTab === 'login' && <LoginForm />}
+        {activeTab === 'logout' && user && <LogoutButton />}
         {activeTab === 'create' && <CreateForm />}
-				{activeTab === 'list' && <UserList />}
-        {activeTab === 'update' && <UpdateForm />}
-				{activeTab === 'delete' && <DeleteButton />}
+        {activeTab === 'list' && user && <UserList />}
+        {activeTab === 'update' && user && <UpdateForm />}
+        {activeTab === 'delete' && user && <DeleteButton />}
         {!activeTab && <p>操作を選択してください。</p>}
       </div>
     </main>

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -32,7 +32,6 @@ export default function UsersPage() {
         ) : (
           <>
             <button onClick={() => setActiveTab('logout')}>ログアウト</button>
-            <button onClick={() => setActiveTab('create')}>作成</button>
             <button onClick={() => setActiveTab('list')}>一覧</button>
             <button onClick={() => setActiveTab('update')}>更新</button>
 				    <button onClick={() => setActiveTab('delete')}>削除</button>


### PR DESCRIPTION
# 概要
- 未ログインユーザーに対する、ページ及び機能制限を追加

# 背景
issue: [#47](https://github.com/1068haruto/python_study/issues/47)

# 変更点
### 機能面
1. 利用できるユーザー機能が認証状態に応じて切り替わるようになった
    - 未ログインユーザーが利用できる：/ページ、/usersページ（ログイン、ユーザー作成のみ）
    - ログイン済ユーザーが利用できる：ログインとユーザー作成以外のすべて
### コード面
1. Auth情報を共有するContextを利用して、表示切り替え判断をする仕様とした
    - 補足：
      現在の各ユーザー機能の表示は、/usersページ内でコンポーネント切り替えによって行なっているため、middlewareを使用した管理ではpathレベルの制限ができない。そのため、auth情報共有を担うcontextを使用したUI管理で対応した。