### PR TITLE
feat: prevent user creation with empty form

### DIFF
--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -9,20 +9,18 @@ from app.crud.user import create_user, update_user, delete_user
 router = APIRouter()
 
 
-# 作成実行時
 @router.post("/users/create")
 def create_user_endpoint(user: UserCreate, db: Session = Depends(get_db)):
     created_user = create_user(db, user)
-    return {"message": "作成成功！", "user_id": created_user.id}
+    return {"user_id": created_user.id}
 
 
-# 一覧表示時
 @router.get("/users/list", response_model=list[UserOut])
 def get_users(db: Session = Depends(get_db)):
     users = db.query(User).all()
     return users
 
-# 更新実行時
+
 @router.put("/users/update/{user_id}")
 def update_user_endpoint(user_id: int, user: UserUpdate, db: Session = Depends(get_db)):
     updated_user = update_user(db, user_id, user)
@@ -31,7 +29,6 @@ def update_user_endpoint(user_id: int, user: UserUpdate, db: Session = Depends(g
     return {"message": "更新成功！", "user_id": updated_user.id}
 
 
-# 削除実行時
 @router.delete("/users/delete/{user_id}")
 def delete_user_endpoint(user_id: int, db: Session = Depends(get_db)):
     success = delete_user(db, user_id)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,14 +1,14 @@
-from pydantic import BaseModel
-from typing import Optional
+from pydantic import BaseModel, Field
+
 
 class UserCreate(BaseModel):
-    name: str
-    password: str
+    name: str = Field(..., min_length=1, description="ユーザー名")
+    password: str = Field(..., min_length=1, description="パスワード")
 
 
 class UserUpdate(BaseModel):
-    name: Optional[str] = None
-    password: Optional[str] = None
+    name: str | None = Field(None, min_length=1, description="更新するユーザー名")
+    password: str | None = Field(None, min_length=1, description="更新するパスワード")
 
 
 class UserOut(BaseModel):

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -11,7 +11,6 @@ def test_create_user():
         "password": "testpassword"
     })
     assert response.status_code == 200
-    assert response.json()["message"] == "作成成功！"
     assert "user_id" in response.json()
 
 

--- a/frontend/src/app/users/create/CreateForm.tsx
+++ b/frontend/src/app/users/create/CreateForm.tsx
@@ -4,23 +4,31 @@ import { useState } from 'react';
 import styles from './CreateForm.module.scss';
 
 export default function CreateForm() {
-  // 状態管理
   const [name, setName] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
   const [createdUserId, setcreatedUserId] = useState<number | null>(null);
 
-  // フォーム送信時に実行
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:8000/users/create', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, password }),
-    });
-    const data = await res.json();
-    setMessage(data.message);
-    setcreatedUserId(data.user_id);
+
+    try {
+      const res = await fetch('http://localhost:8000/users/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password }),
+      });
+
+      if (!res.ok) {
+        throw new Error('レスポンスが正常ではない。');
+      }
+
+      const data = await res.json();
+      setMessage('作成成功！');
+      setcreatedUserId(data.user_id);
+    } catch (error) {
+      setMessage('作成失敗。');
+    }
   };
 
   return (


### PR DESCRIPTION
# 概要
- ユーザー作成フォームの入力が1つでも空の場合、ユーザー作成ができないようにする。

# 背景
issue: [#46](https://github.com/1068haruto/python_study/issues/46)

# 変更点
1. schemaの変更
    - 入力を必須（1文字以上）とした。
2. リファクタ
    - backend側での成功メッセージの処理を削除（backendはデータに集中し、表示はfrontendに）
    - try-catch（制御構文）をユーザー作成のfrontendに追加
    - backend側テストの修正