### PR TITLE
refactor: use requirements.lock in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /code
 
-COPY ./requirements.txt /code/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY ./requirements.lock /code/requirements.lock
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.lock
 
 COPY ./app /code/app
 


### PR DESCRIPTION
# 概要
- backendのパッケージ読み込み改善

# 背景
issue: [#66](https://github.com/1068haruto/python_study/issues/66)

# 変更点
1. backend/Dockerfileの編集
    - これまでrequirements.txtを使用して依存関係をインストールしていたが、requirements.lockを使用する形に変更。