### PR TITLE
Feat/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,19 @@ check_auth_no_token:
 # Python依存関係の管理
 # --------------------------------------------------------
 
-# .PHONYを使い、ファイル名との衝突を避けます
+# ディレクトリ・ファイル名との衝突を衝突回避のため
 .PHONY: install freeze
 
-# 依存関係をインストール
-install:
-	pip install -r backend/requirements.txt
+# 依存関係をインストールし、lockファイルを自動更新
+install: backend/requirements.lock
 
-# 現状の依存関係を書き出し
+# requirements.txtが更新された場合、lockファイルと依存関係を自動更新するルール
+backend/requirements.lock: backend/requirements.txt
+	@echo "Installing dependencies from requirements.txt..."
+	pip install -r backend/requirements.txt
+	@echo "Freezing dependencies into requirements.lock..."
+	pip freeze > backend/requirements.lock
+
+# 手動でlockファイルを作成/更新
 freeze:
 	pip freeze > backend/requirements.lock

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ USER_PASSWORD = testpassword
 COOKIE_FILE = cookies.txt
 
 
-# 認証関連の確認 -----------------------------------------------------------
+# --------------------------------------------------------
+# 認証関連の確認
+# --------------------------------------------------------
 
 # ログイン（cookies.txtにCookieを保存）
 login:
@@ -29,3 +31,19 @@ check_auth:
 # ユーザー認証（tokenなしの状態）
 check_auth_no_token:
 	@curl -X GET $(BACK_URL)/me
+
+
+# --------------------------------------------------------
+# Python依存関係の管理
+# --------------------------------------------------------
+
+# .PHONYを使い、ファイル名との衝突を避けます
+.PHONY: install freeze
+
+# 依存関係をインストール
+install:
+	pip install -r backend/requirements.txt
+
+# 現状の依存関係を書き出し
+freeze:
+	pip freeze > backend/requirements.lock


### PR DESCRIPTION
# 概要
- pip install時のrequirements.lock生成の自動化

# 背景
issue: 

# 変更点
1. Makefileにロックファイル生成のルールを追加
    - installコマンド（依存関係をインストール）は、requirements.lockに依存させ、
    - requirements.lockは、requirements.txtに依存させている。
    これにより、requirements.txtが更新された場合のみロックファイルを自動生成できるようにした。