### PR TITLE
Feat/user

### DIFF
--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -6,12 +6,12 @@ from app.utils.auth import hash_password
 
 
 def create_user(db: Session, user: UserCreate):
-    # 同名の既存ユーザーがいるか確認
+    # 同名ユーザーが存在するか確認
     existing_user = db.query(User).filter(User.name == user.name).first()
     if existing_user:
         raise HTTPException(status_code=400, detail="そのユーザーはすでに存在している")
 
-    # 新規ユーザー作成
+    # 新規作成
     db_user = User(name=user.name, password=hash_password(user.password))
     db.add(db_user)
     db.commit()
@@ -21,14 +21,25 @@ def create_user(db: Session, user: UserCreate):
 
 def update_user(db: Session, user_id: int, user_data: UserUpdate):
     db_user = db.query(User).filter(User.id == user_id).first()
-    if db_user:
-        if user_data.name is not None:
-            db_user.name = user_data.name
-        if user_data.password is not None:
-            db_user.password = hash_password(user_data.password)
+    if not db_user:
+        return None
+    updated = False
+
+    if user_data.name is not None and user_data.name != db_user.name:
+        db_user.name = user_data.name
+        updated = True
+
+    if user_data.password is not None and user_data.password:
+        db_user.password = hash_password(user_data.password)
+        updated = True
+    
+    if updated:
         db.commit()
-        return db_user
-    return None
+        db.refresh(db_user)
+        return {"user_id": db_user.id, "updated": True}
+    else:
+        return {"user_id": db_user.id, "updated": False}
+
 
 
 def delete_user(db: Session, user_id: int):

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -2,7 +2,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 from app.models.user import User
 from app.schemas.user import UserCreate, UserUpdate
-from app.utils.auth import hash_password
+from app.utils.auth import hash_password, verify_password
 
 
 def create_user(db: Session, user: UserCreate):
@@ -28,10 +28,11 @@ def update_user(db: Session, user_id: int, user_data: UserUpdate):
     if user_data.name is not None and user_data.name != db_user.name:
         db_user.name = user_data.name
         updated = True
-
-    if user_data.password is not None and user_data.password:
-        db_user.password = hash_password(user_data.password)
-        updated = True
+    
+    if user_data.password is not None:
+        if not verify_password(user_data.password, db_user.password):
+            db_user.password = hash_password(user_data.password)
+            updated = True
     
     if updated:
         db.commit()

--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -23,10 +23,19 @@ def get_users(db: Session = Depends(get_db)):
 
 @router.put("/users/update/{user_id}")
 def update_user_endpoint(user_id: int, user: UserUpdate, db: Session = Depends(get_db)):
-    updated_user = update_user(db, user_id, user)
-    if updated_user is None:
+    updated_user_info = update_user(db, user_id, user)
+    
+    # ユーザーが見つからない場合
+    if updated_user_info is None:
         raise HTTPException(status_code=404, detail="User not found")
-    return {"user_id": updated_user.id}
+        
+    # updated_user_infoは辞書なので、ブラケット記法でキーにアクセス
+    if updated_user_info.get("updated"):
+        # 更新がある場合
+        return {"user_id": updated_user_info["user_id"], "updated": True}
+    else:
+        # 更新がない場合
+        return {"user_id": updated_user_info["user_id"], "updated": False}
 
 
 @router.delete("/users/delete/{user_id}", response_model=UserDeleteResponse)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -160,6 +160,43 @@ def test_update_user_with_empty_password(client, create_test_user):
     assert any(err["loc"] == ["body", "password"] for err in response.json()["detail"])
 
 
+def test_update_user_no_input(client, create_test_user):
+    """
+    何も入力せずに送信された場合、更新なしとして処理される
+    """
+    created_user_id = create_test_user
+    response = client.put(f"/users/update/{created_user_id}", json={})
+    assert response.status_code == 200
+    assert response.json()["user_id"] == created_user_id
+    assert response.json()["updated"] == False
+
+
+def test_update_user_name_with_same_value(client, create_test_user):
+    """
+    ユーザー名が現状と同じ値の場合、更新なしとして処理される
+    """
+    created_user_id = create_test_user
+    response = client.put(f"/users/update/{created_user_id}", json={
+        "name": "testuser"
+    })
+    assert response.status_code == 200
+    assert response.json()["user_id"] == created_user_id
+    assert response.json()["updated"] == False
+
+
+def test_update_user_password_with_same_value(client, create_test_user):
+    """
+    パスワードが現状と同じ値の場合、更新なしとして処理される
+    """
+    created_user_id = create_test_user
+    response = client.put(f"/users/update/{created_user_id}", json={
+        "password": "testpassword"
+    })
+    assert response.status_code == 200
+    assert response.json()["user_id"] == created_user_id
+    assert response.json()["updated"] == False
+
+
 # --------------------------------------------------------
 # delete
 # --------------------------------------------------------

--- a/frontend/src/app/users/update/UpdateForm.tsx
+++ b/frontend/src/app/users/update/UpdateForm.tsx
@@ -13,10 +13,21 @@ export default function UpdateForm() {
 	const handleSubmit = async (e: React.FormEvent) => {
   	e.preventDefault();
 
+    const isNameEmpty = name.trim() === '';
+    const isPasswordEmpty = password.trim() === '';
+
+    // 未入力で送信された場合、クライアント側で処理を止める
+    if (isNameEmpty && isPasswordEmpty) {
+      setMessage('更新なし。');
+      setUpdatedUserId(null);
+      return;
+    }
+
     try {
       const body: any = {};
-  	  if (name !== '') body.name = name;
-   	  if (password !== '') body.password = password;
+      // rim()で、空白文字だけのデータ送信を防止
+      if (name.trim() !== '') body.name = name;
+      if (password.trim() !== '') body.password = password;
 
       const res = await fetch(`http://localhost:8000/users/update/${userId}`, {
  	  	  method: 'PUT',
@@ -24,15 +35,29 @@ export default function UpdateForm() {
     	  body: JSON.stringify(body),
   	  });
 
+      // 200台以外の場合
       if (!res.ok) {
-        throw new Error('レスポンスが正常ではない。');
+        if (res.status === 404) {
+          setMessage('ユーザーが見つからない。');
+        } else {
+          setMessage('未定義のエラーが発生。');
+        }
+        setUpdatedUserId(null);
+        return;
       }
 
+      // 200台の場合
       const data = await res.json();
-      setMessage('更新成功！');
-      setUpdatedUserId(data.user_id);
+      if (data.updated) {
+        setMessage('更新成功！');
+        setUpdatedUserId(data.user_id);
+      } else {
+        setMessage('更新なし。');
+        setUpdatedUserId(data.user_id);
+      }
     } catch {
       setMessage('更新失敗。');
+      setUpdatedUserId(null);
     }
 	};
 


### PR DESCRIPTION
# 概要
ユーザー情報更新時のフィードバックを改善し、不要な「更新成功」メッセージが表示される問題を修正。

# 背景
issue: [#49](https://github.com/1068haruto/python_study/issues/49)

# 変更点
1.  **`routers/user.py` の修正**
      - `updated_user`から`updated_user_info`に変数をリネーム。
      - 辞書オブジェクトを`updated_user_info["user_id"]`のようにブラケット記法で参照(`AttributeError`の回避)
2.  **`crud/user.py` の修正**
      - ユーザーが見つからない場合に`None`を返し、
      - それ以外の更新成功・更新なしの場合は、`{"user_id": ..., "updated": ...}`という辞書を返すように統一。
3.  **`UpdateForm.tsx` の修正**
      - ステータス(`res.ok`)とJSONデータ(`data.updated`)を組み合わせ、表示メッセージを動的に決める仕様に変更。
      - `404 Not Found`が返る場合のメッセージを追加。
4. **`テストケースの追加`**
      - 未入力の状態で送信した場合にupdated: Falseが返される
      - 既存と同じ名前で送信した場合にupdated: Falseが返される
      - 既存と同じパスワードで送信した場合にupdated: Falseが返される