### PR TITLE
Feat/user

### DIFF
--- a/frontend/src/app/users/delete/DeleteButton.module.scss
+++ b/frontend/src/app/users/delete/DeleteButton.module.scss
@@ -1,25 +1,11 @@
-.container {
-  display: flex;
-  flex-direction: column;
-  max-width: 400px;
-  margin: 50px auto;
-  gap: 12px;
+.button {
+  padding: 8px;
+  background-color: #720a0a;
+  color: white;
+  border: none;
+  cursor: pointer;
 
-  input {
-    padding: 8px;
-    font-size: 16px;
-    background-color: rgb(29, 29, 29);
-  }
-
-  button {
-    padding: 8px;
-    background-color: #720a0a;
-    color: white;
-    border: none;
-    cursor: pointer;
-
-    &:hover {
-      background-color: #af0505;
-    }
+  &:hover {
+    background-color: #af0505;
   }
 }

--- a/frontend/src/app/users/delete/DeleteButton.tsx
+++ b/frontend/src/app/users/delete/DeleteButton.tsx
@@ -3,36 +3,41 @@
 import { useState } from 'react';
 import styles from './DeleteButton.module.scss';
 
-export default function DeleteButton() {
-  const [userId, setUserId] = useState('');
-  const [message, setMessage] = useState('');
-  const [deletedUserId, setDeletedUserId] = useState<number | null>(null);  // 入力IDと削除成功IDの管理を分離するため
+// 親からuserIdと削除成功時のコールバック関数を受け取る
+type DeleteButtonProps = {
+  userId: number;
+  onDeleteSuccess: (deletedId: number) => void;
+  onDeleteError: (error: string) => void;
+};
+
+export default function DeleteButton({ userId, onDeleteSuccess, onDeleteError }: DeleteButtonProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleDelete = async () => {
+    setIsDeleting(true);
+
     try {
       const res = await fetch(`http://localhost:8000/users/delete/${userId}`, {
         method: 'DELETE',
       });
 
       if (!res.ok) {
-        throw new Error('レスポンスが正常ではない。');
+        throw new Error('削除リクエストに失敗。');
       }
 
-      const data = await res.json();
-      setMessage('削除成功！');
-      setDeletedUserId(data.user_id);
-    } catch {
-      setMessage('削除失敗。');
+      onDeleteSuccess(userId);    // 成功時：親に成功を通知
+    } catch (err: any) {
+      onDeleteError(err.message); // 失敗時：親にエラーを通知
+    } finally {
+      setIsDeleting(false);
     }
   };
 
   return (
-    <div className={styles.container}>
-      <h1>ユーザー削除</h1>
-      <input type="number" placeholder="削除するユーザーID" value={userId} onChange={(e) => setUserId(e.target.value)} />
-      <button onClick={handleDelete}>削除</button>
-      <p>{message}</p>
-      {deletedUserId !== null && <p>ユーザーID: {deletedUserId}</p>}
+    <div>
+      <button onClick={handleDelete} disabled={isDeleting} className={styles.button}>
+        {isDeleting ? '削除中...' : '削除'}
+      </button>
     </div>
   );
 }

--- a/frontend/src/app/users/list/UserList.module.scss
+++ b/frontend/src/app/users/list/UserList.module.scss
@@ -9,9 +9,12 @@
     list-style: none;
 
     li {
-      background: rgb(29, 29, 29);
-      padding: 8px;
+      display: flex;
+      justify-content: space-between; // 要素を左右に配置
+      align-items: center;            // 縦の中央
       margin-bottom: 10px;
+      padding: 8px;
+      background: rgb(29, 29, 29);
       color: #ccc;
     }
   }

--- a/frontend/src/app/users/list/UserList.tsx
+++ b/frontend/src/app/users/list/UserList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import styles from './UserList.module.scss';
+import DeleteButton from '@/app/users/delete/DeleteButton';
 
 type User = {
   id: number;
@@ -10,13 +11,46 @@ type User = {
 
 export default function UserList() {
   const [users, setUsers] = useState<User[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('http://localhost:8000/users/list')
-      .then(res => res.json())
-      .then(data => setUsers(data));
-    },[]
-	);
+    const fetchUsers = async () => {
+      try {
+        const res = await fetch('http://localhost:8000/users/list');
+
+        if (!res.ok) {
+          throw new Error('ユーザー一覧の取得に失敗。');
+        }
+
+        const data = await res.json();
+        setUsers(data);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  // 削除成功時
+  const handleUserDeleteSuccess = (deletedId: number) => {
+    // エラーメッセージをクリア
+    setError(null);
+    // リストから削除済ユーザーを除外
+    setUsers(prevUsers => prevUsers.filter(user => user.id !== deletedId));
+  };
+
+  // 削除失敗時
+  const handleUserDeleteError = (errorMessage: string) => {
+    setError(errorMessage);
+  };
+
+  if (isLoading) {
+    return <p>読み込み中...</p>;
+  }
 
   return (
     <div className={styles.list}>
@@ -24,9 +58,15 @@ export default function UserList() {
       <ul>
         {users.map(user => (
           <li key={user.id}>
-            ユーザーID: {user.id} / 名前: {user.name}
+            <span>ユーザーID: {user.id} / 名前: {user.name}</span>
+            <DeleteButton
+              userId={user.id}
+              onDeleteSuccess={handleUserDeleteSuccess}
+              onDeleteError={handleUserDeleteError}
+            />
           </li>
         ))}
+        {error && <p>{error}</p>}
       </ul>
     </div>
   );

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -6,14 +6,13 @@ import { useAuth } from '@/contexts/AuthContext';
 import LoginForm from './login/LoginForm';
 import LogoutButton from './logout/LogoutButton';
 import CreateForm from './create/CreateForm';
-import DeleteButton from './delete/DeleteButton';
 import UpdateForm from './update/UpdateForm';
 import UserList from './list/UserList';
 import styles from './UsersPage.module.scss';
 
 
 export default function UsersPage() {
-  const [activeTab, setActiveTab] = useState<'login' |'logout' | 'create' | 'list' | 'update' | 'delete' | null>(null);
+  const [activeTab, setActiveTab] = useState<'login' |'logout' | 'create' | 'list' | 'update' | null>(null);
 	const router = useRouter();
   const { user } = useAuth();
 
@@ -34,7 +33,6 @@ export default function UsersPage() {
             <button onClick={() => setActiveTab('logout')}>ログアウト</button>
             <button onClick={() => setActiveTab('list')}>一覧</button>
             <button onClick={() => setActiveTab('update')}>更新</button>
-				    <button onClick={() => setActiveTab('delete')}>削除</button>
             <button onClick={() => router.push('/')}>ホームに戻る</button>
           </>
         )}
@@ -47,8 +45,7 @@ export default function UsersPage() {
         {activeTab === 'create' && <CreateForm />}
         {activeTab === 'list' && user && <UserList />}
         {activeTab === 'update' && user && <UpdateForm />}
-        {activeTab === 'delete' && user && <DeleteButton />}
-        {!activeTab && <p>操作を選択してください。</p>}
+        {!activeTab && <p>操作を選択。</p>}
       </div>
     </main>
   );


### PR DESCRIPTION
# 概要
- ユーザー一覧ページに直接ユーザーを削除する機能を追加

# 背景
issue: [#81](https://github.com/1068haruto/python_study/issues/81)

# 変更点
1. **UserList.tsxの変更**
    - 各ユーザー行に`DeleteButton`コンポーネントを配置するよう修正。
    - 削除成功・失敗時の処理を担うコールバック関数（`handleUserDeleteSuccess`, `handleUserDeleteError`）を実装。
    - 子コンポーネントからのエラー通知を受け取り、`UserList`コンポーネントの`error`ステートを更新するロジックを追加。
    - 削除成功時にエラーメッセージをクリアする処理を追加。

2. **DeleteButton.tsxの修正**
    - 親から`userId`、`onDeleteSuccess`、`onDeleteError`を受け取るよう修正。
    - 内部でエラー状態を管理するステートや表示ロジックを削除し、親にエラーを通知する責務に集中させた。

3. **users/page.tsxの変更**
    - ユーザーリストから直接削除できるようになったため、不要となったナビゲーションボタンを削除。

4. **スタイルの調整**
    - `UserList.module.scss`と`DeleteButton.module.scss`を更新し、UIを調整。
